### PR TITLE
feat(azure-ai-search): Add support for document metadata

### DIFF
--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/Document.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/Document.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.store.embedding.azure.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Collection;
 
 public class Document {
@@ -68,6 +67,17 @@ public class Document {
             this.attributes = attributes;
         }
 
+        public void setAttributes(dev.langchain4j.data.document.Metadata metadata) {
+            this.attributes = metadata.toMap().entrySet().stream()
+                    .map(entry -> {
+                        Document.Metadata.Attribute attribute = new Document.Metadata.Attribute();
+                        attribute.setKey(entry.getKey());
+                        attribute.setValue(entry.getValue().toString());
+                        return attribute;
+                    })
+                    .toList();
+        }
+
         public static class Attribute {
             private String key;
 
@@ -91,5 +101,3 @@ public class Document {
         }
     }
 }
-
-

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/DocumentTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/DocumentTest.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.store.embedding.azure.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import org.junit.jupiter.api.Test;
+
+public class DocumentTest {
+
+    @Test
+    void testMetadataConversion() {
+        dev.langchain4j.data.document.Document document =
+                dev.langchain4j.data.document.Document.document("test", Metadata.metadata("keyTest", "valueTest"));
+        Document.Metadata metadata = new Document.Metadata();
+        metadata.setAttributes(document.metadata());
+        assertThat(metadata.getAttributes().stream().toList().get(0).getKey().contains("keyTest"))
+                .isEqualTo(true);
+    }
+}


### PR DESCRIPTION
<details>
<summary>Summary</summary>

This pull request enhances the `AzureAiSearchContentRetriever` in the `langchain4j-azure-ai-search` module to support metadata within documents. The changes involve modifying the `Document` class to include a `Metadata` field, which stores document attributes as key-value pairs.

</details>

<details>
<summary>Details</summary>

- Modified the `Document` class to include a `Metadata` field.
- Updated the `setAttributes` method in `Document.Metadata` to convert `langchain4j.data.document.Metadata` to a list of `Attribute` objects.
- Modified the `AzureAiSearchContentRetriever` to include metadata from `TextSegment` when adding documents to the search index.
- Introduced a new test class, `DocumentTest`, to verify the correct conversion of metadata.

</details>

These changes enable richer document indexing and retrieval based on metadata, improving the overall functionality of the Azure AI Search integration.
