### PR TITLE
feat: Add metadata support to Azure AI Search Content Retriever

### DIFF
--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/Document.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/Document.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.store.embedding.azure.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Collection;
 
 public class Document {
@@ -68,6 +67,17 @@ public class Document {
             this.attributes = attributes;
         }
 
+        public void setAttributes(dev.langchain4j.data.document.Metadata metadata) {
+            this.attributes = metadata.toMap().entrySet().stream()
+                    .map(entry -> {
+                        Document.Metadata.Attribute attribute = new Document.Metadata.Attribute();
+                        attribute.setKey(entry.getKey());
+                        attribute.setValue(entry.getValue().toString());
+                        return attribute;
+                    })
+                    .toList();
+        }
+
         public static class Attribute {
             private String key;
 
@@ -91,5 +101,3 @@ public class Document {
         }
     }
 }
-
-

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/DocumentTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/DocumentTest.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.store.embedding.azure.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import org.junit.jupiter.api.Test;
+
+public class DocumentTest {
+
+    @Test
+    void testMetadataConversion() {
+        dev.langchain4j.data.document.Document document =
+                dev.langchain4j.data.document.Document.document("test", Metadata.metadata("keyTest", "valueTest"));
+        Document.Metadata metadata = new Document.Metadata();
+        metadata.setAttributes(document.metadata());
+        assertThat(metadata.getAttributes().stream().toList().get(0).getKey().contains("keyTest"))
+                .isEqualTo(true);
+    }
+}


### PR DESCRIPTION
<details>
<summary>Summary</summary>

This pull request introduces metadata support to the `AzureAiSearchContentRetriever` in the `langchain4j-azure-ai-search` module. The changes enable storing and retrieving metadata associated with text segments in Azure AI Search.

</details>

<details>
<summary>Details</summary>

*   Modified the `Document` class to include a `Metadata` field for storing key-value pairs representing the segment's metadata.
*   Updated the `AzureAiSearchContentRetriever` class to set the metadata from the `TextSegment` into the `Document` before uploading it to Azure AI Search.
*   Added a new test class, `DocumentTest`, to verify the correct conversion of metadata.

</details>